### PR TITLE
Switch back to makefile for 7 and 8

### DIFF
--- a/.github/workflows/net-7-pipeline-canary.yaml
+++ b/.github/workflows/net-7-pipeline-canary.yaml
@@ -13,13 +13,14 @@ jobs:
       steps:
         - uses: actions/checkout@v2  
         - name: Build and Deploy
-          uses: ./.github/actions/sam-build-and-deploy
+          uses: ./.github/actions/sam-build-and-deploy-native
           with:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
             dotnet-version: '7.0.x'
             template-file-path: ./src/NET7/template.yaml
+            project-directory: ./src/NET7/
             stack-name: net-7-base
             s3-bucket-name: aws-dotnet-lambda-testing
 

--- a/.github/workflows/net-7-pipeline.yaml
+++ b/.github/workflows/net-7-pipeline.yaml
@@ -14,13 +14,14 @@ jobs:
       steps:
         - uses: actions/checkout@v2  
         - name: Build and Deploy
-          uses: ./.github/actions/sam-build-and-deploy
+          uses: ./.github/actions/sam-build-and-deploy-native
           with:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
             dotnet-version: '7.0.x'
             template-file-path: ./src/NET7/template.yaml
+            project-directory: ./src/NET7/
             stack-name: net-7-base
             s3-bucket-name: aws-dotnet-lambda-testing
 

--- a/.github/workflows/net-8-pipeline-canary.yaml
+++ b/.github/workflows/net-8-pipeline-canary.yaml
@@ -13,13 +13,14 @@ jobs:
       steps:
         - uses: actions/checkout@v2  
         - name: Build and Deploy
-          uses: ./.github/actions/sam-build-and-deploy
+          uses: ./.github/actions/sam-build-and-deploy-native
           with:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
             dotnet-version: '8.0.x'
             template-file-path: ./src/NET8/template.yaml
+            project-directory: ./src/NET8/
             stack-name: net-8-base
             s3-bucket-name: aws-dotnet-lambda-testing
 

--- a/.github/workflows/net-8-pipeline.yaml
+++ b/.github/workflows/net-8-pipeline.yaml
@@ -14,13 +14,14 @@ jobs:
       steps:
         - uses: actions/checkout@v2  
         - name: Build and Deploy
-          uses: ./.github/actions/sam-build-and-deploy
+          uses: ./.github/actions/sam-build-and-deploy-native
           with:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
             dotnet-version: '8.0.x'
             template-file-path: ./src/NET8/template.yaml
+            project-directory: ./src/NET8/
             stack-name: net-8-base
             s3-bucket-name: aws-dotnet-lambda-testing
 

--- a/DotnetServerlessDemo.sln
+++ b/DotnetServerlessDemo.sln
@@ -102,6 +102,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared", "src\NET31-OTel\Sh
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NET7", "NET7", "{F2B3C381-621E-4C28-9147-DCB4AAAD50C0}"
 	ProjectSection(SolutionItems) = preProject
+		src\NET7\makefile = src\NET7\makefile
 		src\NET7\template.yaml = src\NET7\template.yaml
 	EndProjectSection
 EndProject
@@ -154,6 +155,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerateLoadTestResults", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NET8", "NET8", "{10804C75-4CC5-4383-8F37-F8C0073460B9}"
 	ProjectSection(SolutionItems) = preProject
+		src\NET8\makefile = src\NET8\makefile
 		src\NET8\template.yaml = src\NET8\template.yaml
 	EndProjectSection
 EndProject

--- a/src/NET7/Makefile
+++ b/src/NET7/Makefile
@@ -1,0 +1,15 @@
+build-GetProductFunction:
+	dotnet clean
+	dotnet publish GetProduct/GetProduct.csproj -c Release -r linux-x64 --self-contained -o $(ARTIFACTS_DIR)
+
+build-GetProductsFunction:
+	dotnet clean
+	dotnet publish GetProducts/GetProducts.csproj -c Release -r linux-x64 --self-contained -o $(ARTIFACTS_DIR)
+
+build-PutProductFunction:
+	dotnet clean
+	dotnet publish PutProduct/PutProduct.csproj -c Release -r linux-x64 --self-contained -o $(ARTIFACTS_DIR)
+
+build-DeleteProductFunction:
+	dotnet clean
+	dotnet publish DeleteProduct/DeleteProduct.csproj -c Release -r linux-x64 --self-contained -o $(ARTIFACTS_DIR)

--- a/src/NET7/template.yaml
+++ b/src/NET7/template.yaml
@@ -15,10 +15,8 @@ Globals:
 Resources:
   GetProductsFunction:
     Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: dotnet7
     Properties:
-      CodeUri: ./GetProducts
+      CodeUri: ./
       Handler: bootstrap
       Events:
         Api:
@@ -30,13 +28,13 @@ Resources:
         - DynamoDBReadPolicy:
             TableName:
               !Ref Table
+    Metadata:
+      BuildMethod: makefile
 
   GetProductFunction:
     Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: dotnet7
     Properties:
-      CodeUri: ./GetProduct
+      CodeUri: ./
       Handler: GetProduct
       Events:
         Api:
@@ -50,13 +48,13 @@ Resources:
             - Effect: Allow
               Action: dynamodb:GetItem
               Resource: !GetAtt Table.Arn
+    Metadata:
+      BuildMethod: makefile
 
   DeleteProductFunction:
     Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: dotnet7
     Properties:
-      CodeUri: ./DeleteProduct
+      CodeUri: ./
       Handler: DeleteProduct
       Events:
         Api:
@@ -72,13 +70,13 @@ Resources:
                 - dynamodb:DeleteItem
                 - dynamodb:GetItem
               Resource: !GetAtt Table.Arn
+    Metadata:
+      BuildMethod: makefile
 
   PutProductFunction:
     Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: dotnet7
     Properties:
-      CodeUri: ./PutProduct
+      CodeUri: ./
       Handler: PutProduct
       Events:
         Api:
@@ -92,6 +90,8 @@ Resources:
             - Effect: Allow
               Action: dynamodb:PutItem
               Resource: !GetAtt Table.Arn
+    Metadata:
+      BuildMethod: makefile
 
   GenerateLoadTestResults:
     Type: AWS::Serverless::Function

--- a/src/NET8/Makefile
+++ b/src/NET8/Makefile
@@ -1,0 +1,15 @@
+build-GetProductFunction:
+	dotnet clean
+	dotnet publish GetProduct/GetProduct.csproj -c Release -r linux-x64 --self-contained -o $(ARTIFACTS_DIR)
+
+build-GetProductsFunction:
+	dotnet clean
+	dotnet publish GetProducts/GetProducts.csproj -c Release -r linux-x64 --self-contained -o $(ARTIFACTS_DIR)
+
+build-PutProductFunction:
+	dotnet clean
+	dotnet publish PutProduct/PutProduct.csproj -c Release -r linux-x64 --self-contained -o $(ARTIFACTS_DIR)
+
+build-DeleteProductFunction:
+	dotnet clean
+	dotnet publish DeleteProduct/DeleteProduct.csproj -c Release -r linux-x64 --self-contained -o $(ARTIFACTS_DIR)

--- a/src/NET8/template.yaml
+++ b/src/NET8/template.yaml
@@ -15,10 +15,8 @@ Globals:
 Resources:
   GetProductsFunction:
     Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: dotnet7
     Properties:
-      CodeUri: ./GetProducts
+      CodeUri: ./
       Handler: bootstrap
       Events:
         Api:
@@ -30,13 +28,13 @@ Resources:
         - DynamoDBReadPolicy:
             TableName:
               !Ref Table
+    Metadata:
+      BuildMethod: makefile
 
   GetProductFunction:
     Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: dotnet7
     Properties:
-      CodeUri: ./GetProduct
+      CodeUri: ./
       Handler: GetProduct
       Events:
         Api:
@@ -50,13 +48,13 @@ Resources:
             - Effect: Allow
               Action: dynamodb:GetItem
               Resource: !GetAtt Table.Arn
+    Metadata:
+      BuildMethod: makefile
 
   DeleteProductFunction:
     Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: dotnet7
     Properties:
-      CodeUri: ./DeleteProduct
+      CodeUri: ./
       Handler: DeleteProduct
       Events:
         Api:
@@ -72,13 +70,13 @@ Resources:
                 - dynamodb:DeleteItem
                 - dynamodb:GetItem
               Resource: !GetAtt Table.Arn
+    Metadata:
+      BuildMethod: makefile
 
   PutProductFunction:
     Type: AWS::Serverless::Function
-    Metadata:
-      BuildMethod: dotnet7
     Properties:
-      CodeUri: ./PutProduct
+      CodeUri: ./
       Handler: PutProduct
       Events:
         Api:
@@ -92,6 +90,8 @@ Resources:
             - Effect: Allow
               Action: dynamodb:PutItem
               Resource: !GetAtt Table.Arn
+    Metadata:
+      BuildMethod: makefile
 
   GenerateLoadTestResults:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
*Description of changes:*
I didn't realize the load test was failing after I removed the Makefile. I opened https://github.com/aws-samples/serverless-dotnet-demo/issues/22 to track that issue since the Action was green. I thought we didn't need the Makefile, but it turns out that we [default to self-contained false inside Amazon.Lambda.Tools](https://github.com/aws/aws-extensions-for-dotnet-cli/blob/599a3508d9c37e1e5784df76ba89abad1f49f7a9/src/Amazon.Lambda.Tools/LambdaDotNetCLIWrapper.cs#L324), which means we do need the Makefile to force a self-contained build. I may open an issue against that repo too and see what they think.

Also, we need to use `sam-build-and-deploy-native` in order to copy the directory.build.props down to the correct place for these, since Makefile builds build in a temp location and have the same problem as container builds in that they can't find that file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
