### PR TITLE
Use latest minor version instead of patch for more up to date testing

### DIFF
--- a/.github/workflows/net-6-containers-pipeline.yaml
+++ b/.github/workflows/net-6-containers-pipeline.yaml
@@ -20,7 +20,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '6.0.x'
+            dotnet-version: '6.x'
             template-file-path: ./src/NET6Containers/template.yaml
             stack-name: net-6-containers-x86-64
             s3-bucket-name: aws-dotnet-lambda-testing

--- a/.github/workflows/net-6-minimal-api.yaml
+++ b/.github/workflows/net-6-minimal-api.yaml
@@ -19,7 +19,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '6.0.x'
+            dotnet-version: '6.x'
             template-file-path: ./src/MinimalAPI/template.yaml
             stack-name: net-6-minimal
             s3-bucket-name: aws-dotnet-lambda-testing

--- a/.github/workflows/net-6-pipeline-canary.yaml
+++ b/.github/workflows/net-6-pipeline-canary.yaml
@@ -18,7 +18,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '6.0.x'
+            dotnet-version: '6.x'
             template-file-path: ./src/NET6/template.yaml
             stack-name: net-6-base
             s3-bucket-name: aws-dotnet-lambda-testing

--- a/.github/workflows/net-6-pipeline.yaml
+++ b/.github/workflows/net-6-pipeline.yaml
@@ -19,7 +19,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '6.0.x'
+            dotnet-version: '6.x'
             template-file-path: ./src/NET6/template.yaml
             stack-name: net-6-base
             s3-bucket-name: aws-dotnet-lambda-testing

--- a/.github/workflows/net-6-top-level-statements.yaml
+++ b/.github/workflows/net-6-top-level-statements.yaml
@@ -19,7 +19,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '6.0.x'
+            dotnet-version: '6.x'
             template-file-path: ./src/NET6TopLevelStatements/template.yaml
             stack-name: net-6-top-level
             s3-bucket-name: aws-dotnet-lambda-testing

--- a/.github/workflows/net-6-with-power-tools.yaml
+++ b/.github/workflows/net-6-with-power-tools.yaml
@@ -19,7 +19,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '6.0.x'
+            dotnet-version: '6.x'
             template-file-path: ./src/NET6WithPowerTools/template.yaml
             stack-name: net-6-power-tools
             s3-bucket-name: aws-dotnet-lambda-testing

--- a/.github/workflows/net-7-native-aot-canary.yaml
+++ b/.github/workflows/net-7-native-aot-canary.yaml
@@ -18,7 +18,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '7.0.x'
+            dotnet-version: '7.x'
             template-file-path: ./src/NET7Native/template.yaml
             project-directory: ./src/NET7Native/
             stack-name: net-7-native

--- a/.github/workflows/net-7-native-aot-pipeline.yaml
+++ b/.github/workflows/net-7-native-aot-pipeline.yaml
@@ -19,7 +19,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '7.0.x'
+            dotnet-version: '7.x'
             template-file-path: ./src/NET7Native/template.yaml
             project-directory: ./src/NET7Native/
             stack-name: net-7-native

--- a/.github/workflows/net-7-pipeline-canary.yaml
+++ b/.github/workflows/net-7-pipeline-canary.yaml
@@ -18,7 +18,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '7.0.x'
+            dotnet-version: '7.x'
             template-file-path: ./src/NET7/template.yaml
             project-directory: ./src/NET7/
             stack-name: net-7-base

--- a/.github/workflows/net-7-pipeline.yaml
+++ b/.github/workflows/net-7-pipeline.yaml
@@ -19,7 +19,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '7.0.x'
+            dotnet-version: '7.x'
             template-file-path: ./src/NET7/template.yaml
             project-directory: ./src/NET7/
             stack-name: net-7-base

--- a/.github/workflows/net-8-pipeline-canary.yaml
+++ b/.github/workflows/net-8-pipeline-canary.yaml
@@ -18,7 +18,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '8.0.x'
+            dotnet-version: '8.x'
             template-file-path: ./src/NET8/template.yaml
             project-directory: ./src/NET8/
             stack-name: net-8-base

--- a/.github/workflows/net-8-pipeline.yaml
+++ b/.github/workflows/net-8-pipeline.yaml
@@ -19,7 +19,7 @@ jobs:
             aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             aws-region: ${{ secrets.AWS_REGION }}
-            dotnet-version: '8.0.x'
+            dotnet-version: '8.x'
             template-file-path: ./src/NET8/template.yaml
             project-directory: ./src/NET8/
             stack-name: net-8-base


### PR DESCRIPTION
*Description of changes:*
As shown here: https://github.com/actions/setup-dotnet#supported-version-syntax

This "installs the latest minor version of the specified major tag, including prerelease versions (preview, rc)" 

This will allow our canaries and performance number to be as up to date as possible. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
