### PR TITLE
Run canaries earlier to avoid peak traffic at midnight

### DIFF
--- a/.github/workflows/net-6-pipeline-canary.yaml
+++ b/.github/workflows/net-6-pipeline-canary.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
   # Run this once a day to check if everything is still working as expected.
-    - cron: "0 0 * * *"
+    - cron: "30 23 * * *"
 
 jobs:
 

--- a/.github/workflows/net-7-native-aot-canary.yaml
+++ b/.github/workflows/net-7-native-aot-canary.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
   # Run this once a day to check if everything is still working as expected.
-    - cron: "0 0 * * *"
+    - cron: "30 23 * * *"
 
 jobs:
 

--- a/.github/workflows/net-7-pipeline-canary.yaml
+++ b/.github/workflows/net-7-pipeline-canary.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
   # Run this once a day to check if everything is still working as expected.
-    - cron: "0 0 * * *"
+    - cron: "30 23 * * *"
 
 jobs:
 

--- a/.github/workflows/net-8-pipeline-canary.yaml
+++ b/.github/workflows/net-8-pipeline-canary.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
   # Run this once a day to check if everything is still working as expected.
-    - cron: "0 0 * * *"
+    - cron: "30 23 * * *"
 
 jobs:
 


### PR DESCRIPTION
Avoid running canaries at midnight as this is a common time for automated scripts to run.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
