### PR TITLE
add .net9 arm

### DIFF
--- a/src/NET9CustomRuntime/template.yaml
+++ b/src/NET9CustomRuntime/template.yaml
@@ -4,7 +4,7 @@ Transform: AWS::Serverless-2016-10-31
 Globals:
   Function:
     MemorySize: 1024
-    Architectures: ["x86_64"]
+    Architectures: [!Ref LambdaArchitecture]
     Runtime: provided.al2023
     Timeout: 30
     Tracing: Active


### PR DESCRIPTION
*Description of changes:*
Forgot to remove hard-coded x86 for .net 9 canaries. This will enable ARM also.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
