### PR TITLE
Adding SnapStart results to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,32 @@ The .NET 8 benchmarks include the number of cold and warm starts, alongside the 
             <td>75.9</td>
         </tr>
         <tr>
+            <th>SnapStart x86_64</th>
+            <td>432</td>
+            <td>689</td>
+            <td>850</td>
+            <td>1081</td>
+            <td>1437</td>
+            <td>15,108</td>
+            <td><b style="color: green">6.8</b></td>
+            <td><b style="color: green">12.3</b></td>
+            <td><b style="color: green">27.1</b></td>
+            <td>94.9</td>
+        </tr>
+        <tr>
+            <th>SnapStart ARM64</th>
+            <td>433</td>
+            <td>686</td>
+            <td>862</td>
+            <td>997</td>
+            <td>1094</td>
+            <td>15,078</td>
+            <td><b style="color: green">7.3</b></td>
+            <td><b style="color: green">14.4</b></td>
+            <td><b style="color: green">30.8</b></td>
+            <td>122.39</td>
+        </tr>
+        <tr>
             <th>x86_64 Native AOT</th>
             <td>758</td>
             <td>322</td>


### PR DESCRIPTION
Used SAM to deploy both ARM and x86 to my account, and then ran the loadtest.sh script against the new URLs.

Results gathered with query from here: https://docs.aws.amazon.com/lambda/latest/dg/snapstart-monitoring.html


Results attached:
![Screenshot 2025-01-07 at 6 32 03 PM](https://github.com/user-attachments/assets/554b25a6-856c-4692-a0bc-0df96e36750c)

![Screenshot 2025-01-07 at 6 32 28 PM](https://github.com/user-attachments/assets/cd60292b-4281-4570-b997-3d76ad7ac2c4)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
